### PR TITLE
Incomplete orders with users attached are not garbage.

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -6,7 +6,7 @@ module Spree
 
     def self.garbage
       garbage_after = Spree::GarbageCleaner::Config.cleanup_days_interval
-      self.incomplete.where("created_at <= ?", garbage_after.days.ago)
+      self.incomplete.where("user_id is NULL").where("created_at <= ?", garbage_after.days.ago)
     end
 
     def garbage?

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -5,8 +5,8 @@ describe Spree::Order do
 
   context "class methods" do
     before do
-      @order_one = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil)
-      @order_two = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil)
+      @order_one = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil, :user => nil)
+      @order_two = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil, :user => nil)
       @order_three = Factory(:order)
     end
 


### PR DESCRIPTION
We need a way to distinguish between incomplete orders that we care about (e.g. payment issues) and those that we don't (orders that were just abandoned midway). The easiest way to do this is to redefine garbage as any order that is incomplete _and_ has no user attached to it.
