### PR TITLE
Use updated_at when determining whether orders are garbage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 before_install: gem install bundler --pre
 before_script:
-  - "bundle exec rake test_app"
-script: "DISPLAY=:99.0 bundle exec rspec spec"
+- bundle exec rake test_app
+script: DISPLAY=:99.0 bundle exec rspec spec
 branches:
   only:
-    - 1-3-stable
+  - 1-3-stable
 rvm:
-  - 1.9.3
+- 1.9.3
+notifications:
+  slack:
+    secure: he/ftnnue2tQp7V3zIJAjpvnv653+geFGsIJcitqQlok/tv8UJkkUxolZTKD8MBNarIXdGnSWDMo4gH7QP3FzHvx2TV5BPwKsU6ShMPcKaDeXlnn9/Z5jQ8zmLO3lEP/saT9tX9SM8HJRScAophk+FIdnGx/YlXQloa1drEAZNA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   only:
   - 1-3-stable
 rvm:
-- 1.9.3
+- 2.1.7
 notifications:
   slack:
     secure: he/ftnnue2tQp7V3zIJAjpvnv653+geFGsIJcitqQlok/tv8UJkkUxolZTKD8MBNarIXdGnSWDMo4gH7QP3FzHvx2TV5BPwKsU6ShMPcKaDeXlnn9/Z5jQ8zmLO3lEP/saT9tX9SM8HJRScAophk+FIdnGx/YlXQloa1drEAZNA=

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,5 @@
 source 'http://rubygems.org'
 
-if RUBY_VERSION < '1.9'
-  gem 'ruby-debug'
-else
-  gem 'debugger'
-end
-
 gemspec
 
 gem 'spree_auth_devise', :git => 'git://github.com/freerunningtechnologies/spree_auth_devise', branch: "1-3-stable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,13 +83,6 @@ GEM
     cocaine (0.5.5)
       climate_control (>= 0.0.3, < 1.0)
     colorize (0.7.5)
-    columnize (0.9.0)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.7)
     deface (1.0.1)
       colorize (>= 0.5.8)
       nokogiri (~> 1.6.0)
@@ -249,10 +242,12 @@ PLATFORMS
 
 DEPENDENCIES
   capybara (= 1.0.1)
-  debugger
   factory_girl (~> 2.6.4)
   ffaker
   rspec-rails (~> 2.9)
   spree_auth_devise!
   spree_garbage_cleaner!
   sqlite3
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -11,7 +11,7 @@ module Spree
 
     def garbage?
       garbage_after = Spree::GarbageCleaner::Config.cleanup_days_interval
-      completed_at.nil? && created_at <= garbage_after.days.ago
+      completed_at.nil? && updated_at <= garbage_after.days.ago
     end
   end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -6,7 +6,7 @@ module Spree
 
     def self.garbage
       garbage_after = Spree::GarbageCleaner::Config.cleanup_days_interval
-      self.incomplete.where("user_id is NULL").where("created_at <= ?", garbage_after.days.ago)
+      self.incomplete.where("user_id is NULL").where("updated_at <= ?", garbage_after.days.ago)
     end
 
     def garbage?

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -5,8 +5,9 @@ describe Spree::Order do
 
   context "class methods" do
     before do
-      @order_one = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil, :user => nil)
-      @order_two = Factory(:order, :created_at => (ordered_on+rand(10)).days.ago, :completed_at => nil, :user => nil)
+      created_at = (ordered_on + rand(10)).days.ago
+      @order_one = Factory(:order, created_at: created_at, updated_at: created_at, completed_at: nil, user: nil)
+      @order_two = Factory(:order, created_at: created_at, updated_at: created_at, completed_at: nil, user: nil)
       @order_three = Factory(:order)
     end
 
@@ -28,17 +29,17 @@ describe Spree::Order do
     end
 
     it "is garbage if not completed and past cleanup_days_interval" do
-      order = Factory.build(:order, :created_at => ordered_on.days.ago, :completed_at => nil)
+      order = Factory.build(:order, :updated_at => ordered_on.days.ago, :completed_at => nil)
       order.garbage?.should be_true
     end
 
     it "is not garbage if not completed and not past cleanup_days_interval" do
-      order = Factory.build(:order, :created_at => (ordered_on-1).days.ago, :completed_at => nil)
+      order = Factory.build(:order, :updated_at => (ordered_on-1).days.ago, :completed_at => nil)
       order.garbage?.should be_false
     end
 
     it "is not garbage if completed and past cleanup_days_interval" do
-      order = Factory.build(:order, :created_at => ordered_on.days.ago, :completed_at => Time.now)
+      order = Factory.build(:order, :updated_at => ordered_on.days.ago, :completed_at => Time.now)
       order.garbage?.should be_false
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -29,22 +29,22 @@ describe Spree::Order do
     end
 
     it "is garbage if not completed and past cleanup_days_interval" do
-      order = Factory.build(:order, :updated_at => ordered_on.days.ago, :completed_at => nil)
+      order = Factory.build(:order, updated_at: ordered_on.days.ago, completed_at: nil)
       order.garbage?.should be_true
     end
 
     it "is not garbage if not completed and not past cleanup_days_interval" do
-      order = Factory.build(:order, :updated_at => (ordered_on-1).days.ago, :completed_at => nil)
+      order = Factory.build(:order, updated_at: (ordered_on-1).days.ago, completed_at: nil)
       order.garbage?.should be_false
     end
 
     it "is not garbage if completed and past cleanup_days_interval" do
-      order = Factory.build(:order, :updated_at => ordered_on.days.ago, :completed_at => Time.now)
+      order = Factory.build(:order, updated_at: ordered_on.days.ago, completed_at: Time.now)
       order.garbage?.should be_false
     end
 
     it "is not garbage if completed and not past cleanup_days_interval" do
-      order = Factory.build(:order, :completed_at => Time.now)
+      order = Factory.build(:order, completed_at: Time.now)
       order.garbage?.should be_false
     end
   end


### PR DESCRIPTION
Currently we use `created_at` but this can have unpredictable results if a user creates an order one day and tries to pay 7 days later, just as the order is being deleted. `updated_at` should be a safer bet.
