### PR TITLE
Revert "Use updated_at when determining whether orders are garbage"

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -6,7 +6,7 @@ module Spree
 
     def self.garbage
       garbage_after = Spree::GarbageCleaner::Config.cleanup_days_interval
-      self.incomplete.where("user_id is NULL").where("updated_at <= ?", garbage_after.days.ago)
+      self.incomplete.where("user_id is NULL").where("created_at <= ?", garbage_after.days.ago)
     end
 
     def garbage?


### PR DESCRIPTION
This reverts commit 64a54a361bbc3703b9958100e57d9c9ef734bec7.

Related: degica/degica-platform#290
